### PR TITLE
과제 1-2 : 커스텀 확장자를 생성하는 API 기능 생성

### DIFF
--- a/src/main/java/com/flow/task/advice/ExceptionCodeConst.java
+++ b/src/main/java/com/flow/task/advice/ExceptionCodeConst.java
@@ -5,7 +5,13 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCodeConst {
 
-    NOT_FOUND_FIXED_EXTENSION(404, "NOT_FOUND_FIXED_EXTENSION", "고정 확장자를 찾을 수 없습니다.");
+    NOT_FOUND_FIXED_EXTENSION(404, "NOT_FOUND_FIXED_EXTENSION", "고정 확장자를 찾을 수 없습니다."),
+    NOT_FOUND_CUSTOM_EXTENSION(404, "NOT_FOUND_CUSTOM_EXTENSION", "커스텀 확장자를 찾을 수 없습니다."),
+
+    ALREADY_EXIST_EXTENSION(409, "ALREADY_EXIST_EXTENSION", "이미 등록된 확장자입니다."),
+
+    LENGTH_EXTENSION_NAME(416, "LENGTH_EXTENSION_NAME", "확장자의 길이를 20글자 이하로 작성해주세요."),
+    EXCEEDED_EXTENSION_LIMIT_200(416, "EXCEEDED_EXTENSION_LIMIT_200", "등록할 수 있는 확장자의 개수가 200개를 초과할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/flow/task/advice/ExceptionController.java
+++ b/src/main/java/com/flow/task/advice/ExceptionController.java
@@ -1,11 +1,14 @@
 package com.flow.task.advice;
 
+import com.flow.task.advice.custom.AlreadyExistException;
+import com.flow.task.advice.custom.ExceededException;
+import com.flow.task.advice.custom.LengthRequiredException;
 import com.flow.task.advice.custom.NotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 @RestControllerAdvice
 public class ExceptionController {
@@ -13,6 +16,21 @@ public class ExceptionController {
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleNotFoundUserException(NotFoundException businessException) {
         return ResponseEntity.status(NOT_FOUND).body(new ExceptionResponse(businessException.getExceptionCodeConst()));
+    }
+
+    @ExceptionHandler(AlreadyExistException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundUserException(AlreadyExistException businessException) {
+        return ResponseEntity.status(CONFLICT).body(new ExceptionResponse(businessException.getExceptionCodeConst()));
+    }
+
+    @ExceptionHandler(LengthRequiredException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundUserException(LengthRequiredException businessException) {
+        return ResponseEntity.status(LENGTH_REQUIRED).body(new ExceptionResponse(businessException.getExceptionCodeConst()));
+    }
+
+    @ExceptionHandler(ExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundUserException(ExceededException businessException) {
+        return ResponseEntity.status(REQUESTED_RANGE_NOT_SATISFIABLE).body(new ExceptionResponse(businessException.getExceptionCodeConst()));
     }
 
 }

--- a/src/main/java/com/flow/task/advice/custom/AlreadyExistException.java
+++ b/src/main/java/com/flow/task/advice/custom/AlreadyExistException.java
@@ -1,0 +1,12 @@
+package com.flow.task.advice.custom;
+
+import com.flow.task.advice.BusinessException;
+import com.flow.task.advice.ExceptionCodeConst;
+
+public class AlreadyExistException extends BusinessException {
+
+    public AlreadyExistException(ExceptionCodeConst exceptionCodeConst) {
+        super(exceptionCodeConst);
+    }
+
+}

--- a/src/main/java/com/flow/task/advice/custom/ExceededException.java
+++ b/src/main/java/com/flow/task/advice/custom/ExceededException.java
@@ -1,0 +1,12 @@
+package com.flow.task.advice.custom;
+
+import com.flow.task.advice.BusinessException;
+import com.flow.task.advice.ExceptionCodeConst;
+
+public class ExceededException extends BusinessException {
+
+    public ExceededException(ExceptionCodeConst exceptionCodeConst) {
+        super(exceptionCodeConst);
+    }
+
+}

--- a/src/main/java/com/flow/task/advice/custom/LengthRequiredException.java
+++ b/src/main/java/com/flow/task/advice/custom/LengthRequiredException.java
@@ -1,0 +1,12 @@
+package com.flow.task.advice.custom;
+
+import com.flow.task.advice.BusinessException;
+import com.flow.task.advice.ExceptionCodeConst;
+
+public class LengthRequiredException extends BusinessException {
+
+    public LengthRequiredException(ExceptionCodeConst exceptionCodeConst) {
+        super(exceptionCodeConst);
+    }
+
+}

--- a/src/main/java/com/flow/task/customExtension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flow/task/customExtension/controller/CustomExtensionController.java
@@ -1,0 +1,26 @@
+package com.flow.task.customExtension.controller;
+
+import com.flow.task.customExtension.request.CreateCustomExtensionRequest;
+import com.flow.task.customExtension.response.CreateCustomExtensionResponse;
+import com.flow.task.customExtension.service.CustomExtensionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CustomExtensionController {
+
+    private final CustomExtensionService customExtensionService;
+
+    public CustomExtensionController(CustomExtensionService customExtensionService) {
+        this.customExtensionService = customExtensionService;
+    }
+
+    @PostMapping("/custom/extension")
+    public ResponseEntity<CreateCustomExtensionResponse> addCustomExtension(@RequestBody CreateCustomExtensionRequest request) {
+        CreateCustomExtensionResponse response = customExtensionService.addCustomExtension(request);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/flow/task/customExtension/domain/CustomExtensions.java
+++ b/src/main/java/com/flow/task/customExtension/domain/CustomExtensions.java
@@ -1,0 +1,31 @@
+package com.flow.task.customExtension.domain;
+
+import com.flow.task.customExtension.request.CreateCustomExtensionRequest;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "custom_extensions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomExtensions {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "extension_name", unique = true, length = 20, nullable = false)
+    private String extensionName;
+
+    public CustomExtensions(String extensionName) {
+        this.extensionName = extensionName;
+    }
+
+    public static CustomExtensions create(CreateCustomExtensionRequest request) {
+        return new CustomExtensions(request.getExtensionName());
+    }
+
+}

--- a/src/main/java/com/flow/task/customExtension/repository/CustomExtensionRepository.java
+++ b/src/main/java/com/flow/task/customExtension/repository/CustomExtensionRepository.java
@@ -1,0 +1,10 @@
+package com.flow.task.customExtension.repository;
+
+import com.flow.task.customExtension.domain.CustomExtensions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomExtensionRepository extends JpaRepository<CustomExtensions, Long> {
+
+    Boolean existsByExtensionName(String extensionName);
+
+}

--- a/src/main/java/com/flow/task/customExtension/request/CreateCustomExtensionRequest.java
+++ b/src/main/java/com/flow/task/customExtension/request/CreateCustomExtensionRequest.java
@@ -1,0 +1,13 @@
+package com.flow.task.customExtension.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateCustomExtensionRequest {
+
+    private String extensionName;
+
+}

--- a/src/main/java/com/flow/task/customExtension/response/CreateCustomExtensionResponse.java
+++ b/src/main/java/com/flow/task/customExtension/response/CreateCustomExtensionResponse.java
@@ -1,0 +1,14 @@
+package com.flow.task.customExtension.response;
+
+import lombok.Getter;
+
+@Getter
+public class CreateCustomExtensionResponse {
+
+    private String CustomExtensionName;
+
+    public CreateCustomExtensionResponse(String customExtensionName) {
+        CustomExtensionName = customExtensionName;
+    }
+
+}

--- a/src/main/java/com/flow/task/customExtension/service/CustomExtensionService.java
+++ b/src/main/java/com/flow/task/customExtension/service/CustomExtensionService.java
@@ -1,0 +1,56 @@
+package com.flow.task.customExtension.service;
+
+import com.flow.task.advice.ExceptionCodeConst;
+import com.flow.task.advice.custom.AlreadyExistException;
+import com.flow.task.advice.custom.ExceededException;
+import com.flow.task.advice.custom.LengthRequiredException;
+import com.flow.task.customExtension.domain.CustomExtensions;
+import com.flow.task.customExtension.repository.CustomExtensionRepository;
+import com.flow.task.customExtension.request.CreateCustomExtensionRequest;
+import com.flow.task.customExtension.response.CreateCustomExtensionResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class CustomExtensionService {
+
+    private static final int MAX_EXTENSION_NAME_LENGTH = 20;
+    private static final int MAX_EXTENSION_COUNT = 200;
+
+    private final CustomExtensionRepository customExtensionRepository;
+
+    public CustomExtensionService(CustomExtensionRepository customExtensionRepository) {
+        this.customExtensionRepository = customExtensionRepository;
+    }
+
+    public CreateCustomExtensionResponse addCustomExtension(CreateCustomExtensionRequest request) {
+        existExtensionByName(request);
+        validateExtensionNameLength(request);
+        validateExtensionSize();
+
+        CustomExtensions customExtensions = CustomExtensions.create(request);
+        customExtensionRepository.save(customExtensions);
+
+        return new CreateCustomExtensionResponse(customExtensions.getExtensionName());
+    }
+
+    private void existExtensionByName(CreateCustomExtensionRequest request) {
+        if (customExtensionRepository.existsByExtensionName(request.getExtensionName())) {
+            throw new AlreadyExistException(ExceptionCodeConst.ALREADY_EXIST_EXTENSION);
+        }
+    }
+
+    private void validateExtensionNameLength(CreateCustomExtensionRequest request) {
+        if (request.getExtensionName().length() > MAX_EXTENSION_NAME_LENGTH) {
+            throw new LengthRequiredException(ExceptionCodeConst.LENGTH_EXTENSION_NAME);
+        }
+    }
+
+    private void validateExtensionSize() {
+        if (customExtensionRepository.count() > MAX_EXTENSION_COUNT) {
+            throw new ExceededException(ExceptionCodeConst.EXCEEDED_EXTENSION_LIMIT_200);
+        }
+    }
+
+}

--- a/src/main/java/com/flow/task/fixedExtension/controller/FixedExtensionController.java
+++ b/src/main/java/com/flow/task/fixedExtension/controller/FixedExtensionController.java
@@ -1,7 +1,7 @@
-package com.flow.task.controller;
+package com.flow.task.fixedExtension.controller;
 
-import com.flow.task.response.UpdateFixedExtensionStatusResponse;
-import com.flow.task.service.FixedExtensionService;
+import com.flow.task.fixedExtension.response.UpdateFixedExtensionStatusResponse;
+import com.flow.task.fixedExtension.service.FixedExtensionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;

--- a/src/main/java/com/flow/task/fixedExtension/domain/ExtensionStatus.java
+++ b/src/main/java/com/flow/task/fixedExtension/domain/ExtensionStatus.java
@@ -1,4 +1,4 @@
-package com.flow.task.domain;
+package com.flow.task.fixedExtension.domain;
 
 import lombok.Getter;
 

--- a/src/main/java/com/flow/task/fixedExtension/domain/FixedExtensions.java
+++ b/src/main/java/com/flow/task/fixedExtension/domain/FixedExtensions.java
@@ -1,4 +1,4 @@
-package com.flow.task.domain;
+package com.flow.task.fixedExtension.domain;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/flow/task/fixedExtension/domain/FixedExtensions.java
+++ b/src/main/java/com/flow/task/fixedExtension/domain/FixedExtensions.java
@@ -16,17 +16,11 @@ public class FixedExtensions {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
-    private String extension;
+    @Column(name = "extension_name", unique = true, nullable = false)
+    private String extensionName;
 
     @Enumerated(EnumType.STRING)
     private ExtensionStatus status = ExtensionStatus.UNCHECK;
-
-    public FixedExtensions(Long id, String extension, ExtensionStatus status) {
-        this.id = id;
-        this.extension = extension;
-        this.status = status;
-    }
 
     public void fixedExtensionCheck() {
         this.status = ExtensionStatus.CHECK;

--- a/src/main/java/com/flow/task/fixedExtension/repository/FixedExtensionRepository.java
+++ b/src/main/java/com/flow/task/fixedExtension/repository/FixedExtensionRepository.java
@@ -1,7 +1,7 @@
-package com.flow.task.repository;
+package com.flow.task.fixedExtension.repository;
 
-import com.flow.task.domain.ExtensionStatus;
-import com.flow.task.domain.FixedExtensions;
+import com.flow.task.fixedExtension.domain.ExtensionStatus;
+import com.flow.task.fixedExtension.domain.FixedExtensions;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/flow/task/fixedExtension/response/UpdateFixedExtensionStatusResponse.java
+++ b/src/main/java/com/flow/task/fixedExtension/response/UpdateFixedExtensionStatusResponse.java
@@ -1,4 +1,4 @@
-package com.flow.task.response;
+package com.flow.task.fixedExtension.response;
 
 import lombok.Getter;
 

--- a/src/main/java/com/flow/task/fixedExtension/service/FixedExtensionService.java
+++ b/src/main/java/com/flow/task/fixedExtension/service/FixedExtensionService.java
@@ -1,10 +1,10 @@
-package com.flow.task.service;
+package com.flow.task.fixedExtension.service;
 
 import com.flow.task.advice.custom.NotFoundException;
-import com.flow.task.domain.ExtensionStatus;
-import com.flow.task.domain.FixedExtensions;
-import com.flow.task.repository.FixedExtensionRepository;
-import com.flow.task.response.UpdateFixedExtensionStatusResponse;
+import com.flow.task.fixedExtension.domain.ExtensionStatus;
+import com.flow.task.fixedExtension.domain.FixedExtensions;
+import com.flow.task.fixedExtension.repository.FixedExtensionRepository;
+import com.flow.task.fixedExtension.response.UpdateFixedExtensionStatusResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/flow/task/flowController.java
+++ b/src/main/java/com/flow/task/flowController.java
@@ -1,4 +1,4 @@
-package com.flow.task.controller;
+package com.flow.task;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;


### PR DESCRIPTION
## :mag: 개요
close #12 
## :memo: 작업사항
커스텀 확장자 과제 2-2 내용인 커스텀 확장자를 추가할 수 있는 API 기능을 만들었습니다.

확장자 추가 시 최대 입력 길이는 20자리, 최대 200개까지 추가가 가능하다는 제한사항을 고려하여 만들었습니다.
