### PR TITLE
이슈 : 커스텀 확장자 추가 시 고정 확장자는 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'javax.servlet:jstl'
 	implementation "org.apache.tomcat.embed:tomcat-embed-jasper"
 
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+	compileOnly 'org.springframework.boot:spring-boot-starter-tomcat'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/flow/task/advice/ExceptionCodeConst.java
+++ b/src/main/java/com/flow/task/advice/ExceptionCodeConst.java
@@ -8,6 +8,7 @@ public enum ExceptionCodeConst {
     NOT_FOUND_FIXED_EXTENSION(404, "NOT_FOUND_FIXED_EXTENSION", "고정 확장자를 찾을 수 없습니다."),
     NOT_FOUND_CUSTOM_EXTENSION(404, "NOT_FOUND_CUSTOM_EXTENSION", "커스텀 확장자를 찾을 수 없습니다."),
 
+    ALREADY_FIXED_EXIST_EXTENSION(409, "ALREADY_FIXED_EXIST_EXTENSION", "이미 고정 확장자로 등록되었습니다."),
     ALREADY_EXIST_EXTENSION(409, "ALREADY_EXIST_EXTENSION", "이미 등록된 확장자입니다."),
 
     LENGTH_EXTENSION_NAME(416, "LENGTH_EXTENSION_NAME", "확장자의 길이를 20글자 이하로 작성해주세요."),

--- a/src/main/java/com/flow/task/customExtension/service/CustomExtensionService.java
+++ b/src/main/java/com/flow/task/customExtension/service/CustomExtensionService.java
@@ -12,11 +12,15 @@ import com.flow.task.customExtension.response.CreateCustomExtensionResponse;
 import com.flow.task.customExtension.response.CustomExtensionResponse;
 import com.flow.task.customExtension.response.CustomExtensionResponseList;
 import com.flow.task.customExtension.response.DeleteCustomExtensionResponse;
+import com.flow.task.fixedExtension.repository.FixedExtensionRepository;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.flow.task.advice.ExceptionCodeConst.ALREADY_FIXED_EXIST_EXTENSION;
 
 @Service
 @Transactional
@@ -25,9 +29,11 @@ public class CustomExtensionService {
     private static final int MAX_EXTENSION_NAME_LENGTH = 20;
     private static final int MAX_EXTENSION_COUNT = 200;
 
+    private final FixedExtensionRepository fixedExtensionRepository;
     private final CustomExtensionRepository customExtensionRepository;
 
-    public CustomExtensionService(CustomExtensionRepository customExtensionRepository) {
+    public CustomExtensionService(FixedExtensionRepository fixedExtensionRepository, CustomExtensionRepository customExtensionRepository) {
+        this.fixedExtensionRepository = fixedExtensionRepository;
         this.customExtensionRepository = customExtensionRepository;
     }
 
@@ -35,6 +41,7 @@ public class CustomExtensionService {
         existExtensionByName(request);
         validateExtensionNameLength(request);
         validateExtensionSize();
+        validateIncludeFixedExtension(request);
 
         CustomExtensions customExtensions = CustomExtensions.create(request);
         customExtensionRepository.save(customExtensions);
@@ -52,7 +59,7 @@ public class CustomExtensionService {
     }
 
     public CustomExtensionResponseList getCustomExtensionList() {
-        List<CustomExtensions> customExtensionsList = customExtensionRepository.findAll();
+        List<CustomExtensions> customExtensionsList = customExtensionRepository.findAll(Sort.by("id").ascending());
         List<CustomExtensionResponse> customExtensionResponseList = customExtensionsList.stream()
                 .map(CustomExtensionResponse::create)
                 .collect(Collectors.toList());
@@ -75,6 +82,12 @@ public class CustomExtensionService {
     private void validateExtensionSize() {
         if (customExtensionRepository.count() > MAX_EXTENSION_COUNT) {
             throw new ExceededException(ExceptionCodeConst.EXCEEDED_EXTENSION_LIMIT_200);
+        }
+    }
+
+    private void validateIncludeFixedExtension(CreateCustomExtensionRequest request) {
+        if (fixedExtensionRepository.existsByExtensionName(request.getExtensionName())) {
+            throw new AlreadyExistException(ALREADY_FIXED_EXIST_EXTENSION);
         }
     }
 

--- a/src/main/java/com/flow/task/fixedExtension/repository/FixedExtensionRepository.java
+++ b/src/main/java/com/flow/task/fixedExtension/repository/FixedExtensionRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface FixedExtensionRepository extends JpaRepository<FixedExtensions, Long> {
 
+    Boolean existsByExtensionName(String extensionName);
+
     Optional<FixedExtensions> findByIdAndStatus(Long id, ExtensionStatus status);
 
 }

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -72,7 +72,7 @@ function addCustomExtension() {
 
     const inputValue = document.getElementById("custom-extension-input").value.trim();
 
-    if (fixedExtensions.includes(inputValue)) {
+    if (fixedExtensions.some(extObj => extObj.name === inputValue)) {
         alert("이미 고정 확장자로 등록된 항목입니다.");
         document.getElementById("custom-extension-input").value = "";
         return;
@@ -94,6 +94,7 @@ function addCustomExtension() {
             dataType: "json",
             success: function(response) {
                 customExtensions.push(response.customExtensionName);
+                fetchCustomExtensions();
                 displayCustomExtensions();
                 document.getElementById("custom-extension-input").value = "";
             },
@@ -104,6 +105,7 @@ function addCustomExtension() {
             }
         });
     }
+
 }
 
 const MAX_SELECTED = 200;


### PR DESCRIPTION
## :mag: 개요
close #26 
## :memo: 작업사항
커스텀 확장자 추가 시 고정 확장자 리스트를 확인하여 DB 추가 및 랜더링되지 않게 해결했습니다.